### PR TITLE
update table name for geocoder

### DIFF
--- a/db/migrate/20150807141851_create_users.rb
+++ b/db/migrate/20150807141851_create_users.rb
@@ -7,7 +7,7 @@ class CreateUsers < ActiveRecord::Migration
       t.string :email, null: false, unique: true
       t.string :password_digest, null: false
       t.text :bio, default: nil
-      t.integer :zip_code, null: false
+      t.string :zip_code, null: false
       t.float :longitude, null: false
       t.float :latitude, null: false
       t.string :github_link, default: nil


### PR DESCRIPTION
Updated migration table for goecoder to take a string for an input as zip code instead of an integer
