### PR TITLE
Fix add new tags bug

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -10,7 +10,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(project_params)
     tags = params[:tags].split(',')
     tags.each do |tag|
-      valid_tag = Tag.find_by(name: tag.strip.capitalize)
+      valid_tag = Tag.find_by(name: tag.strip)
       if valid_tag
         @project.tags << valid_tag
       else


### PR DESCRIPTION
@AlinaJahnes @ChristineSchatz @Jguzik83 Fixed the bug we had with adding tags to the project.

The bug was occurring with tags with capital letters in the middle of them. Removing the `capitalize` method when finding tags fixed this. Tags like JavaScript were saved as 'JavaScript' in the database but we were looking for a 'Javascript' tag so it wasn't finding them.
