### PR TITLE
Fix missing word and move about paragraph up one level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-== Welcome to The HIVE
+##Welcome to The HIVE
+
+The Hive is a social networking site where software developers can find other developers to collaborate on side projects with. It uses an in-app messaging system for smooth, fast communication and a geolocation search to find projects in your city or zip code. Users can also search for projects by language or framework.
 
 ##Team Members:
 #### [Anna Karingal](https://github.com/annakaringal)
 #### [Alina Jahnes](https://github.com/alinajahnes)
 #### [Christine Schatz](https://github.com/ChristineSchatz)
 #### [Jason Guzik](https://github.com/jguzik83)
-
-The <Hive> is a social networking site where software developers can find other developers to collaborate on side projects with. It uses an in-app messaging system for smooth, fast communication and a geolocation search to find projects in your city or zip code. Users can also search for projects by language or framework.
 
 ##Live URL:
 [Heroku](http://code-hive.herokuapp.com/)
@@ -24,12 +24,13 @@ $ rails s
 ```
 
 ##Technologies
-* [Rails] - a powerful and flexible framework for Ruby applications
-* [jQuery UI] - for our drop down, auto-complete menus
-* [AJAX] - for generating smoother results
-* [Mailboxer] - a Ruby gem for streamlined in-app communication
-* [Google Geocoder API] - an API that seamlessly records the latitude and longitude of any zip code or city
-* [Materialize] - a responsive frontend framework
+* Rails - a powerful and flexible framework for Ruby applications
+* jQuery UI - for our drop down, auto-complete menus
+* RSpec - for testing of features, controllers, and models
+* AJAX - for generating smoother results
+* Mailboxer - a Ruby gem for streamlined in-app communication
+* Google Geocoder API - an API that seamlessly records the latitude and longitude of any zip code or city
+* Materialize - a responsive frontend framework
 
 
 ### Trello


### PR DESCRIPTION
@annakaringal oopsies. turns out these < > things caused the "hive" to be missing. I also moved the paragraph up under "welcome to the hive" so people can read the description straightaway. thanks :pineapple:
